### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -96,7 +96,7 @@
 
 			// Expand "target" if it's not a jQuery object already.
 				if (typeof config.target != 'jQuery')
-					config.target = $(config.target);
+					config.target = jQuery.find(config.target);
 
 		// Panel.
 


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/Website/security/code-scanning/1](https://github.com/ScottBrenner/Website/security/code-scanning/1)

To fix the problem, we need to ensure that `config.target` is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of the `$()` function, which ensures that the input is always interpreted as a selector.

- Replace the line where `config.target` is assigned using `$()` with `jQuery.find`.
- Ensure that `config.target` is a valid jQuery object after the assignment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
